### PR TITLE
[BUG] Crafter: Multiple Running Recipes at once 

### DIFF
--- a/src/main/java/de/darkfinst/drugsadder/structures/crafter/DACrafter.java
+++ b/src/main/java/de/darkfinst/drugsadder/structures/crafter/DACrafter.java
@@ -205,6 +205,11 @@ public class DACrafter extends DAInvStructure {
      * @param recipe The recipe to start
      */
     public void startRecipe(@Nullable HumanEntity who, @NotNull DACrafterRecipe recipe) {
+        // Check if a process is already running
+        if (this.getProcess().isRunning()) {
+            return;
+        }
+
         CrafterStartRecipeEvent crafterStartRecipeEvent = new CrafterStartRecipeEvent(who, this, recipe);
         Bukkit.getPluginManager().callEvent(crafterStartRecipeEvent);
         if (!crafterStartRecipeEvent.isCancelled()) {

--- a/src/main/java/de/darkfinst/drugsadder/structures/crafter/DACrafterProcess.java
+++ b/src/main/java/de/darkfinst/drugsadder/structures/crafter/DACrafterProcess.java
@@ -32,4 +32,13 @@ public class DACrafterProcess extends DAProcess {
     public void restart(DAStructure daStructure) {
         //Do nothing - not needed
     }
+
+    /**
+     * Checks if the process is running
+     *
+     * @return True if the process is running
+     */
+    public boolean isRunning() {
+        return recipe != null;
+    }
 }


### PR DESCRIPTION
Got an bug report: 

In the crafter it is possible that you can start multiple crafter processes at once. 

My fix for this: 
Create an methode that returns if the recipe is null or not. 
If it's null then succeed. If not cancel it.